### PR TITLE
Implement token validation when sending messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -92,6 +92,9 @@ def main():
                 continue
 
             token = input("enter your token to send a message: ").strip()
+            if not validate_token(token):
+                print("token was invalid or already used. can't send.")
+                continue
             if is_token_frozen(token):
                 print("this token has been frozen. you can't send anything.")
                 continue
@@ -119,6 +122,7 @@ def main():
             }
 
             save_data(data)
+            use_token(token)
             log_event("Sender", "MessageSent")
             print("encrypted message saved successfully.")
 


### PR DESCRIPTION
## Summary
- validate tokens before sending messages
- mark tokens used after sending

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py <<'EOF'
11
EOF` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_683f4f5039b4832db9b8eaefed3fd0f2